### PR TITLE
Fix missing submodule source tree when archiving shallow copy

### DIFF
--- a/.github/workflows/grpc_source_sync.yml
+++ b/.github/workflows/grpc_source_sync.yml
@@ -8,16 +8,20 @@ jobs:
   gRPC-Native-Source-Shallow-Sync:
     runs-on: macos-latest
     steps:
-      - name: Checkout Repo
+      - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Shallow Source Sync
+      - name: Install git-achive-all
+        run: brew install git-archive-all
+
+      - name: Shallow source source
         run: scripts/sync_grpc_src_shallow.sh
 
-      - run: |
+      - name: Collect revision hash
+        run: |
           echo "grpc_src_revision=$(cat native_src/REVISION.txt)" >> $GITHUB_ENV
 
-      - name: Create Pull Request
+      - name: Create or update pull request
         uses: peter-evans/create-pull-request@v3
         with:
           title: "[bot] gRPC native source shallow sync"
@@ -25,4 +29,9 @@ jobs:
           body: |
             Native source sync at revision @${{ env.grpc_src_revision }}
           delete-branch	: true
-          reviewers: dennycd
+          labels: |
+            kind/bot
+            area/automation
+          reviewers: |
+            dennycd
+            sampajano

--- a/scripts/sync_grpc_src_shallow.sh
+++ b/scripts/sync_grpc_src_shallow.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 set -ex
 
-# preping the folder
+# Prepping the folder
 rm -rf tmp && mkdir tmp
 rm -rf native_src && mkdir native_src
 
 ### Clone grpc and extract shallow source copy
 git clone https://github.com/grpc/grpc.git tmp
 pushd tmp
+REVISION=$(git rev-parse HEAD)
 git submodule update --init
-git archive HEAD --format=zip > ../src.zip
-echo $(git rev-parse HEAD) > ../native_src/REVISION.txt
+git-archive-all ../native_src.zip
 popd
 
 ### Unload shallow copy
-unzip src.zip -d native_src/
-rm -rf src.zip && rm -rf tmp
+unzip native_src.zip
+rm -rf native_src.zip && rm -rf tmp
+
+### Record revision
+echo $REVISION > native_src/REVISION.txt


### PR DESCRIPTION
Change Summary 

* Switch to git-archive-all to include missing git submodule source tree 
* update label & reviewer for bot's source sync PR
