### PR TITLE
[native_fix] Patch upb 64 to 32 bit conversion warning

### DIFF
--- a/native_src/third_party/upb/upb/msg.c
+++ b/native_src/third_party/upb/upb/msg.c
@@ -53,7 +53,7 @@ static bool realloc_internal(upb_msg *msg, size_t need, upb_arena *arena) {
   upb_msg_internal *in = upb_msg_getinternal(msg);
   if (!in->internal) {
     /* No internal data, allocate from scratch. */
-    size_t size = UPB_MAX(128, _upb_lg2ceilsize(need + overhead));
+    size_t size = UPB_MAX(128, _upb_lg2ceilsize((int)(need + overhead)));
     upb_msg_internaldata *internal = upb_arena_malloc(arena, size);
     if (!internal) return false;
     internal->size = size;

--- a/native_src/third_party/upb/upb/table.c
+++ b/native_src/third_party/upb/upb/table.c
@@ -133,7 +133,7 @@ static bool init(upb_table *t, uint8_t size_lg2, upb_arena *a) {
 
   t->count = 0;
   t->size_lg2 = size_lg2;
-  t->mask = upb_table_size(t) ? upb_table_size(t) - 1 : 0;
+  t->mask = (uint32_t)(upb_table_size(t) ? upb_table_size(t) - 1 : 0);
   t->max_count = upb_table_size(t) * MAX_LOAD;
   bytes = upb_table_size(t) * sizeof(upb_tabent);
   if (bytes > 0) {
@@ -443,7 +443,7 @@ const uint64_t kWyhashSalt[5] = {
 };
 
 static uint32_t table_hash(const char *p, size_t n) {
-  return Wyhash(p, n, 0, kWyhashSalt);
+  return (uint32_t)Wyhash(p, n, 0, kWyhashSalt);
 }
 
 static uint32_t strhash(upb_tabkey key) {
@@ -462,7 +462,7 @@ bool upb_strtable_init(upb_strtable *t, size_t expected_size, upb_arena *a) {
   // Multiply by approximate reciprocal of MAX_LOAD (0.85), with pow2 denominator.
   size_t need_entries = (expected_size + 1) * 1204 / 1024;
   UPB_ASSERT(need_entries >= expected_size * 0.85);
-  int size_lg2 = _upb_lg2ceil(need_entries);
+  int size_lg2 = _upb_lg2ceil((int)need_entries);
   return init(&t->t, size_lg2, a);
 }
 

--- a/native_src/third_party/upb/upb/upb.c
+++ b/native_src/third_party/upb/upb/upb.c
@@ -232,7 +232,7 @@ upb_arena *upb_arena_init(void *mem, size_t n, upb_alloc *alloc) {
   a->block_alloc = alloc;
   a->parent = a;
   a->refcount = 1;
-  a->last_size = UPB_MAX(128, n);
+  a->last_size = UPB_MAX(128, (uint32_t)n);
   a->head.ptr = mem;
   a->head.end = UPB_PTR_AT(mem, n - sizeof(*a), char);
   a->freelist = NULL;

--- a/native_src/third_party/upb/upb/upb.h
+++ b/native_src/third_party/upb/upb/upb.h
@@ -339,7 +339,7 @@ UPB_INLINE uint64_t _upb_be_swap64(uint64_t val) {
   if (_upb_isle()) {
     return val;
   } else {
-    return ((uint64_t)_upb_be_swap32(val) << 32) | _upb_be_swap32(val >> 32);
+    return ((uint64_t)_upb_be_swap32((uint32_t)val) << 32) | _upb_be_swap32(val >> 32);
   }
 }
 


### PR DESCRIPTION
### Summary 

Explicit casting to avoid 64 to 32 bit conversion clang warning ([-Wshorten-64-to-32](https://clang.llvm.org/docs/DiagnosticsReference.html#wshorten-64-to-32))  as seen from gRPC and Firebase SDK.  This is a release branch hot fix and the patch will also be upstreamed to upb repo (https://github.com/protocolbuffers/upb)


### Test 

swift build && swift test 

--- 
Umbrella: https://github.com/grpc/grpc-ios/issues/83
Firebase: https://github.com/firebase/firebase-ios-sdk/issues/9790 