### PR TITLE
Revert "Apply warning suppress flags to match Cocoapod build"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -80,11 +80,6 @@ let package = Package(
         .headerSearchPath("src/core/ext/upb-generated/"),
         .headerSearchPath("src/core/ext/upbdefs-generated/"),
         .define("GRPC_ARES", to: "0"),
-        .unsafeFlags([
-          "-Wno-shorten-64-to-32",
-          "-Wno-comma",
-          "-Wno-unreachable-code",
-        ]),
       ],
       linkerSettings: [
         .linkedFramework("CoreFoundation"),
@@ -122,11 +117,6 @@ let package = Package(
         .headerSearchPath("include/"),
         .headerSearchPath("third_party/upb/"),
         .headerSearchPath("src/core/ext/upb-generated"),
-        .unsafeFlags([
-          "-Wno-shorten-64-to-32",
-          "-Wno-comma",
-          "-Wno-unreachable-code",
-        ]),
       ]
     ),
     .testTarget(


### PR DESCRIPTION
Reverts grpc/grpc-ios#85 due to unsafeFlags usage 