### PR TITLE
[Process] update shallow copy sync script to take in optional revision

### DIFF
--- a/scripts/sync_grpc_src_shallow.sh
+++ b/scripts/sync_grpc_src_shallow.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -ex
 
+# Optional checkout revision, or default to grpc master
+TARGET_REV=${1:-master}
+
 # Prepping the folder
 rm -rf tmp && mkdir tmp
 rm -rf native_src && mkdir native_src
@@ -8,6 +11,7 @@ rm -rf native_src && mkdir native_src
 ### Clone grpc and extract shallow source copy
 git clone https://github.com/grpc/grpc.git tmp
 pushd tmp
+git checkout $TARGET_REV
 REVISION=$(git rev-parse HEAD)
 git submodule update --init
 git-archive-all ../native_src.zip


### PR DESCRIPTION
Parameterize shallow sync script to checkout a specified revision. Latest master branch is used if no revisiion/tag is specified. 

### Test and verify

run the following locally and verify the correct target revision is copied into native_src 

```bash
// v1.44.0 release 
./scripts/sync_grpc_src_shallow.sh v1.44.0
```

```bash
// master branch 
./scripts/sync_grpc_src_shallow.sh 
```