### PR TITLE
[Test] Introduce SPM test sample app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ bazel_format_virtual_environment/
 # SPM
 .build/
 Package.resolved
+.swiftpm/

--- a/scripts/build_test_spm_samples.sh
+++ b/scripts/build_test_spm_samples.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -ex
+
+## Build gRPC Sample App with Swift Package Manager and Verify Build Success
+
+# build configuration and paths
+SAMPLE_PRJ=tests/spm/gRPCSample/gRPCSample.xcodeproj
+SCHEME=gRPCSample
+DESTINATION='name=iPhone 11'
+
+# custom build flags
+BUILD_FLAGS="
+  GCC_TREAT_WARNINGS_AS_ERRORS=YES
+"
+
+# build via xcodebuild command line
+time xcodebuild \
+-project $SAMPLE_PRJ \
+-scheme $SCHEME \
+-verbose \
+-destination "${DESTINATION}" \
+build \
+$BUILD_FLAGS

--- a/tests/spm/README.md
+++ b/tests/spm/README.md
@@ -1,0 +1,3 @@
+### Overview
+
+This folder contains test targets related to Swift Package Manager distribution of gRPC-iOS

--- a/tests/spm/gRPCSample/README.md
+++ b/tests/spm/gRPCSample/README.md
@@ -1,0 +1,8 @@
+### Overview
+
+Manually created sample app using gRPC via Swift Package Manager
+
+### Project Settings
+
+* XCode 13.3 (13E113)
+* SwiftUI & Swift

--- a/tests/spm/gRPCSample/build.xcconfig
+++ b/tests/spm/gRPCSample/build.xcconfig
@@ -1,0 +1,12 @@
+//
+//  build.xcconfig
+//  gRPCSample
+//
+//  Created by Denny Dai on 6/2/22.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+
+GCC_TREAT_WARNINGS_AS_ERRORS = YES

--- a/tests/spm/gRPCSample/gRPCSample.xcodeproj/project.pbxproj
+++ b/tests/spm/gRPCSample/gRPCSample.xcodeproj/project.pbxproj
@@ -1,0 +1,617 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		7463595E2849791200149F78 /* build.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 7463595D2849791200149F78 /* build.xcconfig */; };
+		7463595F2849791200149F78 /* build.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 7463595D2849791200149F78 /* build.xcconfig */; };
+		746359602849791200149F78 /* build.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 7463595D2849791200149F78 /* build.xcconfig */; };
+		74A9233F28495904008A8B94 /* gRPCSampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A9233E28495904008A8B94 /* gRPCSampleApp.swift */; };
+		74A9234128495904008A8B94 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A9234028495904008A8B94 /* ContentView.swift */; };
+		74A9234328495906008A8B94 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 74A9234228495906008A8B94 /* Assets.xcassets */; };
+		74A9234628495906008A8B94 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 74A9234528495906008A8B94 /* Preview Assets.xcassets */; };
+		74A9235028495906008A8B94 /* gRPCSampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A9234F28495906008A8B94 /* gRPCSampleTests.swift */; };
+		74A9235A28495906008A8B94 /* gRPCSampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A9235928495906008A8B94 /* gRPCSampleUITests.swift */; };
+		74A9235C28495906008A8B94 /* gRPCSampleUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A9235B28495906008A8B94 /* gRPCSampleUITestsLaunchTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		74A9234C28495906008A8B94 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 74A9233328495904008A8B94 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 74A9233A28495904008A8B94;
+			remoteInfo = gRPCSample;
+		};
+		74A9235628495906008A8B94 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 74A9233328495904008A8B94 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 74A9233A28495904008A8B94;
+			remoteInfo = gRPCSample;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		7463595D2849791200149F78 /* build.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = build.xcconfig; sourceTree = "<group>"; };
+		74A9233B28495904008A8B94 /* gRPCSample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = gRPCSample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		74A9233E28495904008A8B94 /* gRPCSampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = gRPCSampleApp.swift; sourceTree = "<group>"; };
+		74A9234028495904008A8B94 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		74A9234228495906008A8B94 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		74A9234528495906008A8B94 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		74A9234B28495906008A8B94 /* gRPCSampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = gRPCSampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		74A9234F28495906008A8B94 /* gRPCSampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = gRPCSampleTests.swift; sourceTree = "<group>"; };
+		74A9235528495906008A8B94 /* gRPCSampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = gRPCSampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		74A9235928495906008A8B94 /* gRPCSampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = gRPCSampleUITests.swift; sourceTree = "<group>"; };
+		74A9235B28495906008A8B94 /* gRPCSampleUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = gRPCSampleUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		74A9236C28495B2B008A8B94 /* grpc-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "grpc-ios"; path = ../../..; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		74A9233828495904008A8B94 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		74A9234828495906008A8B94 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		74A9235228495906008A8B94 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		74A9233228495904008A8B94 = {
+			isa = PBXGroup;
+			children = (
+				7463595D2849791200149F78 /* build.xcconfig */,
+				74A9236C28495B2B008A8B94 /* grpc-ios */,
+				74A9233D28495904008A8B94 /* gRPCSample */,
+				74A9234E28495906008A8B94 /* gRPCSampleTests */,
+				74A9235828495906008A8B94 /* gRPCSampleUITests */,
+				74A9233C28495904008A8B94 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		74A9233C28495904008A8B94 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				74A9233B28495904008A8B94 /* gRPCSample.app */,
+				74A9234B28495906008A8B94 /* gRPCSampleTests.xctest */,
+				74A9235528495906008A8B94 /* gRPCSampleUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		74A9233D28495904008A8B94 /* gRPCSample */ = {
+			isa = PBXGroup;
+			children = (
+				74A9233E28495904008A8B94 /* gRPCSampleApp.swift */,
+				74A9234028495904008A8B94 /* ContentView.swift */,
+				74A9234228495906008A8B94 /* Assets.xcassets */,
+				74A9234428495906008A8B94 /* Preview Content */,
+			);
+			path = gRPCSample;
+			sourceTree = "<group>";
+		};
+		74A9234428495906008A8B94 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				74A9234528495906008A8B94 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		74A9234E28495906008A8B94 /* gRPCSampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				74A9234F28495906008A8B94 /* gRPCSampleTests.swift */,
+			);
+			path = gRPCSampleTests;
+			sourceTree = "<group>";
+		};
+		74A9235828495906008A8B94 /* gRPCSampleUITests */ = {
+			isa = PBXGroup;
+			children = (
+				74A9235928495906008A8B94 /* gRPCSampleUITests.swift */,
+				74A9235B28495906008A8B94 /* gRPCSampleUITestsLaunchTests.swift */,
+			);
+			path = gRPCSampleUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		74A9233A28495904008A8B94 /* gRPCSample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 74A9235F28495906008A8B94 /* Build configuration list for PBXNativeTarget "gRPCSample" */;
+			buildPhases = (
+				74A9233728495904008A8B94 /* Sources */,
+				74A9233828495904008A8B94 /* Frameworks */,
+				74A9233928495904008A8B94 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				74A9236E28495B41008A8B94 /* PBXTargetDependency */,
+				74A9237028495B41008A8B94 /* PBXTargetDependency */,
+			);
+			name = gRPCSample;
+			productName = gRPCSample;
+			productReference = 74A9233B28495904008A8B94 /* gRPCSample.app */;
+			productType = "com.apple.product-type.application";
+		};
+		74A9234A28495906008A8B94 /* gRPCSampleTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 74A9236228495906008A8B94 /* Build configuration list for PBXNativeTarget "gRPCSampleTests" */;
+			buildPhases = (
+				74A9234728495906008A8B94 /* Sources */,
+				74A9234828495906008A8B94 /* Frameworks */,
+				74A9234928495906008A8B94 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				74A9234D28495906008A8B94 /* PBXTargetDependency */,
+			);
+			name = gRPCSampleTests;
+			productName = gRPCSampleTests;
+			productReference = 74A9234B28495906008A8B94 /* gRPCSampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		74A9235428495906008A8B94 /* gRPCSampleUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 74A9236528495906008A8B94 /* Build configuration list for PBXNativeTarget "gRPCSampleUITests" */;
+			buildPhases = (
+				74A9235128495906008A8B94 /* Sources */,
+				74A9235228495906008A8B94 /* Frameworks */,
+				74A9235328495906008A8B94 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				74A9235728495906008A8B94 /* PBXTargetDependency */,
+			);
+			name = gRPCSampleUITests;
+			productName = gRPCSampleUITests;
+			productReference = 74A9235528495906008A8B94 /* gRPCSampleUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		74A9233328495904008A8B94 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1330;
+				LastUpgradeCheck = 1330;
+				TargetAttributes = {
+					74A9233A28495904008A8B94 = {
+						CreatedOnToolsVersion = 13.3;
+					};
+					74A9234A28495906008A8B94 = {
+						CreatedOnToolsVersion = 13.3;
+						TestTargetID = 74A9233A28495904008A8B94;
+					};
+					74A9235428495906008A8B94 = {
+						CreatedOnToolsVersion = 13.3;
+						TestTargetID = 74A9233A28495904008A8B94;
+					};
+				};
+			};
+			buildConfigurationList = 74A9233628495904008A8B94 /* Build configuration list for PBXProject "gRPCSample" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 74A9233228495904008A8B94;
+			productRefGroup = 74A9233C28495904008A8B94 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				74A9233A28495904008A8B94 /* gRPCSample */,
+				74A9234A28495906008A8B94 /* gRPCSampleTests */,
+				74A9235428495906008A8B94 /* gRPCSampleUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		74A9233928495904008A8B94 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7463595E2849791200149F78 /* build.xcconfig in Resources */,
+				74A9234628495906008A8B94 /* Preview Assets.xcassets in Resources */,
+				74A9234328495906008A8B94 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		74A9234928495906008A8B94 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7463595F2849791200149F78 /* build.xcconfig in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		74A9235328495906008A8B94 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				746359602849791200149F78 /* build.xcconfig in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		74A9233728495904008A8B94 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				74A9234128495904008A8B94 /* ContentView.swift in Sources */,
+				74A9233F28495904008A8B94 /* gRPCSampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		74A9234728495906008A8B94 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				74A9235028495906008A8B94 /* gRPCSampleTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		74A9235128495906008A8B94 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				74A9235C28495906008A8B94 /* gRPCSampleUITestsLaunchTests.swift in Sources */,
+				74A9235A28495906008A8B94 /* gRPCSampleUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		74A9234D28495906008A8B94 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 74A9233A28495904008A8B94 /* gRPCSample */;
+			targetProxy = 74A9234C28495906008A8B94 /* PBXContainerItemProxy */;
+		};
+		74A9235728495906008A8B94 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 74A9233A28495904008A8B94 /* gRPCSample */;
+			targetProxy = 74A9235628495906008A8B94 /* PBXContainerItemProxy */;
+		};
+		74A9236E28495B41008A8B94 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 74A9236D28495B41008A8B94 /* gRPC-Core */;
+		};
+		74A9237028495B41008A8B94 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 74A9236F28495B41008A8B94 /* gRPC-cpp */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		74A9235D28495906008A8B94 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
+			};
+			name = Debug;
+		};
+		74A9235E28495906008A8B94 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		74A9236028495906008A8B94 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"gRPCSample/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.grpc.gRPCSample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		74A9236128495906008A8B94 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"gRPCSample/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.grpc.gRPCSample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		74A9236328495906008A8B94 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.grpc.gRPCSampleTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/gRPCSample.app/gRPCSample";
+			};
+			name = Debug;
+		};
+		74A9236428495906008A8B94 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.grpc.gRPCSampleTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/gRPCSample.app/gRPCSample";
+			};
+			name = Release;
+		};
+		74A9236628495906008A8B94 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.grpc.gRPCSampleUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = gRPCSample;
+			};
+			name = Debug;
+		};
+		74A9236728495906008A8B94 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.grpc.gRPCSampleUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = gRPCSample;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		74A9233628495904008A8B94 /* Build configuration list for PBXProject "gRPCSample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				74A9235D28495906008A8B94 /* Debug */,
+				74A9235E28495906008A8B94 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		74A9235F28495906008A8B94 /* Build configuration list for PBXNativeTarget "gRPCSample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				74A9236028495906008A8B94 /* Debug */,
+				74A9236128495906008A8B94 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		74A9236228495906008A8B94 /* Build configuration list for PBXNativeTarget "gRPCSampleTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				74A9236328495906008A8B94 /* Debug */,
+				74A9236428495906008A8B94 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		74A9236528495906008A8B94 /* Build configuration list for PBXNativeTarget "gRPCSampleUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				74A9236628495906008A8B94 /* Debug */,
+				74A9236728495906008A8B94 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		74A9236D28495B41008A8B94 /* gRPC-Core */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = "gRPC-Core";
+		};
+		74A9236F28495B41008A8B94 /* gRPC-cpp */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = "gRPC-cpp";
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 74A9233328495904008A8B94 /* Project object */;
+}

--- a/tests/spm/gRPCSample/gRPCSample/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/tests/spm/gRPCSample/gRPCSample/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/tests/spm/gRPCSample/gRPCSample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/tests/spm/gRPCSample/gRPCSample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,93 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/tests/spm/gRPCSample/gRPCSample/Assets.xcassets/Contents.json
+++ b/tests/spm/gRPCSample/gRPCSample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/tests/spm/gRPCSample/gRPCSample/ContentView.swift
+++ b/tests/spm/gRPCSample/gRPCSample/ContentView.swift
@@ -1,0 +1,21 @@
+//
+//  ContentView.swift
+//  gRPCSample
+//
+//  Created by Denny Dai on 6/2/22.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, world!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/tests/spm/gRPCSample/gRPCSample/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/tests/spm/gRPCSample/gRPCSample/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/tests/spm/gRPCSample/gRPCSample/gRPCSampleApp.swift
+++ b/tests/spm/gRPCSample/gRPCSample/gRPCSampleApp.swift
@@ -1,0 +1,17 @@
+//
+//  gRPCSampleApp.swift
+//  gRPCSample
+//
+//  Created by Denny Dai on 6/2/22.
+//
+
+import SwiftUI
+
+@main
+struct gRPCSampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/tests/spm/gRPCSample/gRPCSampleTests/gRPCSampleTests.swift
+++ b/tests/spm/gRPCSample/gRPCSampleTests/gRPCSampleTests.swift
@@ -1,0 +1,36 @@
+//
+//  gRPCSampleTests.swift
+//  gRPCSampleTests
+//
+//  Created by Denny Dai on 6/2/22.
+//
+
+import XCTest
+@testable import gRPCSample
+
+class gRPCSampleTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/tests/spm/gRPCSample/gRPCSampleUITests/gRPCSampleUITests.swift
+++ b/tests/spm/gRPCSample/gRPCSampleUITests/gRPCSampleUITests.swift
@@ -1,0 +1,41 @@
+//
+//  gRPCSampleUITests.swift
+//  gRPCSampleUITests
+//
+//  Created by Denny Dai on 6/2/22.
+//
+
+import XCTest
+
+class gRPCSampleUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/tests/spm/gRPCSample/gRPCSampleUITests/gRPCSampleUITestsLaunchTests.swift
+++ b/tests/spm/gRPCSample/gRPCSampleUITests/gRPCSampleUITestsLaunchTests.swift
@@ -1,0 +1,32 @@
+//
+//  gRPCSampleUITestsLaunchTests.swift
+//  gRPCSampleUITests
+//
+//  Created by Denny Dai on 6/2/22.
+//
+
+import XCTest
+
+class gRPCSampleUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
Manually created XCode sample test app project for swift package manager build test. 
 - Manual xcode project reflects default app/xcode build settings as used by gRPC/iOS clients. 
 - The ios app locally depends on grpc-ios/Package.swift and allows us to easily test local dev modification and in CI. 
 - xcconfig build setting to customize and turn on the following flags 
    * GCC_TREAT_WARNINGS_AS_ERRORS=YES  to treat warning as erros 


Also introduce build_test_spm_samples.sh for command line build test via xcodebuild

### Build and Verify 

run build test script and verify success 

```bash 
./scripts/build_test_spm_samples.sh
```