### PR TITLE
[native] 32bit conversion warning fix for gRPC C-Core

### DIFF
--- a/native_src/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
+++ b/native_src/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
@@ -646,7 +646,7 @@ void XdsClusterResolverLb::OnEndpointChanged(size_t index,
                            mechanism.pending_priority_list->begin(),
                            mechanism.pending_priority_list->end());
       priority_index += mechanism.num_priorities;
-      mechanism.num_priorities = mechanism.pending_priority_list->size();
+      mechanism.num_priorities = (uint32_t)(mechanism.pending_priority_list->size());
       mechanism.pending_priority_list.reset();
     } else {
       priority_list.insert(

--- a/native_src/src/core/ext/filters/fault_injection/fault_injection_filter.cc
+++ b/native_src/src/core/ext/filters/fault_injection/fault_injection_filter.cc
@@ -170,7 +170,7 @@ void ChannelData::Destroy(grpc_channel_element* elem) {
 
 ChannelData::ChannelData(grpc_channel_element* elem,
                          grpc_channel_element_args* args)
-    : index_(grpc_channel_stack_filter_instance_number(args->channel_stack,
+    : index_((int)grpc_channel_stack_filter_instance_number(args->channel_stack,
                                                        elem)) {}
 
 // CallData::ResumeBatchCanceller

--- a/native_src/src/core/ext/filters/rbac/rbac_filter.cc
+++ b/native_src/src/core/ext/filters/rbac/rbac_filter.cc
@@ -82,7 +82,7 @@ void RbacFilter::CallData::RecvInitialMetadataReady(void* user_data,
     } else {
       RbacFilter* chand = static_cast<RbacFilter*>(elem->channel_data);
       auto* authorization_engine =
-          method_params->authorization_engine(chand->index_);
+          method_params->authorization_engine((int)(chand->index_));
       if (authorization_engine
               ->Evaluate(EvaluateArgs(calld->recv_initial_metadata_,
                                       &chand->per_channel_evaluate_args_))

--- a/native_src/src/core/ext/transport/binder/wire_format/binder.h
+++ b/native_src/src/core/ext/transport/binder/wire_format/binder.h
@@ -52,11 +52,11 @@ class WritableParcel {
   virtual absl::Status WriteByteArray(const int8_t* buffer, int32_t length) = 0;
 
   absl::Status WriteByteArrayWithLength(absl::string_view buffer) {
-    absl::Status status = WriteInt32(buffer.length());
+    absl::Status status = WriteInt32((int32_t)(buffer.length()));
     if (!status.ok()) return status;
     if (buffer.empty()) return absl::OkStatus();
     return WriteByteArray(reinterpret_cast<const int8_t*>(buffer.data()),
-                          buffer.length());
+                          (int32_t)(buffer.length()));
   }
 };
 

--- a/native_src/src/core/ext/transport/binder/wire_format/wire_writer.cc
+++ b/native_src/src/core/ext/transport/binder/wire_format/wire_writer.cc
@@ -38,7 +38,7 @@ absl::Status WireWriterImpl::WriteInitialMetadata(const Transaction& tx,
     // Only client sends method ref.
     RETURN_IF_ERROR(parcel->WriteString(tx.GetMethodRef()));
   }
-  RETURN_IF_ERROR(parcel->WriteInt32(tx.GetPrefixMetadata().size()));
+  RETURN_IF_ERROR(parcel->WriteInt32((int32_t)(tx.GetPrefixMetadata().size())));
   for (const auto& md : tx.GetPrefixMetadata()) {
     RETURN_IF_ERROR(parcel->WriteByteArrayWithLength(md.first));
     RETURN_IF_ERROR(parcel->WriteByteArrayWithLength(md.second));
@@ -52,7 +52,7 @@ absl::Status WireWriterImpl::WriteTrailingMetadata(const Transaction& tx,
     if (tx.GetFlags() & kFlagStatusDescription) {
       RETURN_IF_ERROR(parcel->WriteString(tx.GetStatusDesc()));
     }
-    RETURN_IF_ERROR(parcel->WriteInt32(tx.GetSuffixMetadata().size()));
+    RETURN_IF_ERROR(parcel->WriteInt32((int32_t)(tx.GetSuffixMetadata().size())));
     for (const auto& md : tx.GetSuffixMetadata()) {
       RETURN_IF_ERROR(parcel->WriteByteArrayWithLength(md.first));
       RETURN_IF_ERROR(parcel->WriteByteArrayWithLength(md.second));

--- a/native_src/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/native_src/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -2235,7 +2235,7 @@ static void close_from_api(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
 
   size_t msg_len = message.length();
   GPR_ASSERT(msg_len <= UINT32_MAX);
-  grpc_core::VarintWriter<1> msg_len_writer(msg_len);
+  grpc_core::VarintWriter<1> msg_len_writer((uint32_t)msg_len);
   message_pfx = GRPC_SLICE_MALLOC(14 + msg_len_writer.length());
   p = GRPC_SLICE_START_PTR(message_pfx);
   *p++ = 0x00; /* literal header, not indexed */

--- a/native_src/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
+++ b/native_src/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
@@ -215,7 +215,7 @@ class BinaryStringValue {
   explicit BinaryStringValue(Slice value, bool use_true_binary_metadata)
       : wire_value_(
             GetWireValue(std::move(value), use_true_binary_metadata, true)),
-        len_val_(wire_value_.length) {}
+        len_val_((uint32_t)(wire_value_.length)) {}
 
   size_t prefix_length() const {
     return len_val_.length() +
@@ -239,7 +239,7 @@ class BinaryStringValue {
 class NonBinaryStringValue {
  public:
   explicit NonBinaryStringValue(Slice value)
-      : value_(std::move(value)), len_val_(value_.length()) {}
+      : value_(std::move(value)), len_val_((uint32_t)(value_.length())) {}
 
   size_t prefix_length() const { return len_val_.length(); }
 
@@ -255,7 +255,7 @@ class NonBinaryStringValue {
 class StringKey {
  public:
   explicit StringKey(Slice key)
-      : key_(std::move(key)), len_key_(key_.length()) {}
+      : key_(std::move(key)), len_key_((uint32_t)(key_.length())) {}
 
   size_t prefix_length() const { return 1 + len_key_.length(); }
 
@@ -342,7 +342,7 @@ void HPackCompressor::SliceIndex::EmitTo(absl::string_view key,
   using It = std::vector<ValueIndex>::iterator;
   It prev = values_.end();
   uint32_t transport_length =
-      key.length() + value.length() + hpack_constants::kEntryOverhead;
+      (uint32_t)(key.length() + value.length() + hpack_constants::kEntryOverhead);
   if (transport_length > HPackEncoderTable::MaxEntrySize()) {
     framer->EmitLitHdrWithNonBinaryStringKeyNotIdx(Slice::FromStaticString(key),
                                                    value.Ref());
@@ -567,7 +567,7 @@ void HPackCompressor::Framer::Encode(UserAgentMetadata, const Slice& slice) {
   }
   EncodeAlwaysIndexed(
       &compressor_->user_agent_index_, "user-agent", slice.Ref(),
-      10 /* user-agent */ + slice.size() + hpack_constants::kEntryOverhead);
+      (uint32_t)(10 /* user-agent */ + slice.size() + hpack_constants::kEntryOverhead));
 }
 
 void HPackCompressor::Framer::Encode(GrpcStatusMetadata,
@@ -584,7 +584,7 @@ void HPackCompressor::Framer::Encode(GrpcStatusMetadata,
   Slice key = Slice::FromStaticString(GrpcStatusMetadata::key());
   Slice value = Slice::FromInt64(code);
   const uint32_t transport_length =
-      key.length() + value.length() + hpack_constants::kEntryOverhead;
+      (uint32_t)(key.length() + value.length() + hpack_constants::kEntryOverhead);
   if (index != nullptr) {
     *index = compressor_->table_.AllocateIndex(transport_length);
     EmitLitHdrWithNonBinaryStringKeyIncIdx(std::move(key), std::move(value));
@@ -606,7 +606,7 @@ void HPackCompressor::Framer::Encode(GrpcEncodingMetadata,
   auto key = Slice::FromStaticString(GrpcEncodingMetadata::key());
   auto encoded_value = GrpcEncodingMetadata::Encode(value);
   uint32_t transport_length =
-      key.length() + encoded_value.length() + hpack_constants::kEntryOverhead;
+      (uint32_t)(key.length() + encoded_value.length() + hpack_constants::kEntryOverhead);
   if (index != nullptr) {
     *index = compressor_->table_.AllocateIndex(transport_length);
     EmitLitHdrWithNonBinaryStringKeyIncIdx(std::move(key),
@@ -630,7 +630,7 @@ void HPackCompressor::Framer::Encode(GrpcAcceptEncodingMetadata,
   auto key = Slice::FromStaticString(GrpcAcceptEncodingMetadata::key());
   auto encoded_value = GrpcAcceptEncodingMetadata::Encode(value);
   uint32_t transport_length =
-      key.length() + encoded_value.length() + hpack_constants::kEntryOverhead;
+      (uint32_t)(key.length() + encoded_value.length() + hpack_constants::kEntryOverhead);
   compressor_->grpc_accept_encoding_index_ =
       compressor_->table_.AllocateIndex(transport_length);
   compressor_->grpc_accept_encoding_ = value;

--- a/native_src/src/core/ext/transport/chttp2/transport/hpack_encoder_table.cc
+++ b/native_src/src/core/ext/transport/chttp2/transport/hpack_encoder_table.cc
@@ -58,7 +58,7 @@ bool HPackEncoderTable::SetMaxSize(uint32_t max_table_size) {
       hpack_constants::EntriesForBytes(max_table_size);
   // TODO(ctiller): integrate with ResourceQuota to rebuild smaller when we can.
   if (max_table_elems > elem_size_.size()) {
-    Rebuild(std::max(max_table_elems, 2 * elem_size_.size()));
+    Rebuild((uint32_t)(std::max(max_table_elems, 2 * elem_size_.size())));
   }
   return true;
 }

--- a/native_src/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/native_src/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -1126,7 +1126,7 @@ class HPackParser::Parser {
     const auto transport_size = key_string.size() + value_slice.size() +
                                 hpack_constants::kEntryOverhead;
     return grpc_metadata_batch::Parse(
-        key->string_view(), std::move(value_slice), transport_size,
+        key->string_view(), std::move(value_slice), (uint32_t)transport_size,
         [key_string](absl::string_view error, const Slice& value) {
           ReportMetadataParseError(key_string, error, value.as_string_view());
         });

--- a/native_src/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
+++ b/native_src/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
@@ -217,7 +217,7 @@ GPR_ATTRIBUTE_NOINLINE HPackTable::Memento MakeMemento(size_t i) {
   auto sm = kStaticTable[i];
   return grpc_metadata_batch::Parse(
       sm.key, Slice::FromStaticString(sm.value),
-      strlen(sm.key) + strlen(sm.value) + hpack_constants::kEntryOverhead,
+      (uint32_t)(strlen(sm.key) + strlen(sm.value) + hpack_constants::kEntryOverhead),
       [](absl::string_view, const Slice&) {
         abort();  // not expecting to see this
       });

--- a/native_src/src/core/ext/xds/file_watcher_certificate_provider_factory.cc
+++ b/native_src/src/core/ext/xds/file_watcher_certificate_provider_factory.cc
@@ -131,7 +131,7 @@ FileWatcherCertificateProviderFactory::CreateCertificateProvider(
       file_watcher_config->private_key_file(),
       file_watcher_config->identity_cert_file(),
       file_watcher_config->root_cert_file(),
-      file_watcher_config->refresh_interval_ms() / GPR_MS_PER_SEC);
+      (unsigned int)(file_watcher_config->refresh_interval_ms() / GPR_MS_PER_SEC));
 }
 
 void FileWatcherCertificateProviderInit() {

--- a/native_src/src/core/lib/compression/compression_internal.cc
+++ b/native_src/src/core/lib/compression/compression_internal.cc
@@ -117,7 +117,7 @@ CompressionAlgorithmSet CompressionAlgorithmSet::FromUint32(uint32_t value) {
   CompressionAlgorithmSet set;
   for (size_t i = 0; i < GRPC_COMPRESS_ALGORITHMS_COUNT; i++) {
     if (value & (1u << i)) {
-      set.set_.set(i);
+      set.set_.set((int)i);
     }
   }
   return set;
@@ -152,7 +152,7 @@ bool CompressionAlgorithmSet::IsSet(
     grpc_compression_algorithm algorithm) const {
   size_t i = static_cast<size_t>(algorithm);
   if (i < GRPC_COMPRESS_ALGORITHMS_COUNT) {
-    return set_.is_set(i);
+    return set_.is_set((int)i);
   } else {
     return false;
   }
@@ -161,14 +161,14 @@ bool CompressionAlgorithmSet::IsSet(
 void CompressionAlgorithmSet::Set(grpc_compression_algorithm algorithm) {
   size_t i = static_cast<size_t>(algorithm);
   if (i < GRPC_COMPRESS_ALGORITHMS_COUNT) {
-    set_.set(i);
+    set_.set((int)i);
   }
 }
 
 std::string CompressionAlgorithmSet::ToString() const {
   absl::InlinedVector<const char*, GRPC_COMPRESS_ALGORITHMS_COUNT> segments;
   for (size_t i = 0; i < GRPC_COMPRESS_ALGORITHMS_COUNT; i++) {
-    if (set_.is_set(i)) {
+    if (set_.is_set((int)i)) {
       segments.push_back(CompressionAlgorithmAsString(
           static_cast<grpc_compression_algorithm>(i)));
     }
@@ -196,7 +196,7 @@ CompressionAlgorithmSet CompressionAlgorithmSet::FromString(
 uint32_t CompressionAlgorithmSet::ToLegacyBitmask() const {
   uint32_t x = 0;
   for (size_t i = 0; i < GRPC_COMPRESS_ALGORITHMS_COUNT; i++) {
-    if (set_.is_set(i)) {
+    if (set_.is_set((int)i)) {
       x |= (1u << i);
     }
   }

--- a/native_src/src/core/lib/gpr/time_precise.cc
+++ b/native_src/src/core/lib/gpr/time_precise.cc
@@ -149,7 +149,7 @@ gpr_cycle_counter gpr_get_cycle_counter() {
 gpr_timespec gpr_cycle_counter_to_time(gpr_cycle_counter cycles) {
   gpr_timespec ts;
   ts.tv_sec = static_cast<int64_t>(cycles / GPR_US_PER_SEC);
-  ts.tv_nsec = static_cast<int64_t>((cycles - ts.tv_sec * GPR_US_PER_SEC) *
+  ts.tv_nsec = static_cast<int32_t>((cycles - ts.tv_sec * GPR_US_PER_SEC) *
                                     GPR_NS_PER_US);
   ts.clock_type = GPR_CLOCK_PRECISE;
   return ts;

--- a/native_src/src/core/lib/gprpp/status_helper.cc
+++ b/native_src/src/core/lib/gprpp/status_helper.cc
@@ -258,7 +258,7 @@ void StatusAddChild(absl::Status* status, absl::Status child) {
     children = *old_children;
   }
   char head_buf[sizeof(uint32_t)];
-  EncodeUInt32ToBytes(buf_len, head_buf);
+  EncodeUInt32ToBytes((uint32_t)buf_len, head_buf);
   children.Append(absl::string_view(head_buf, sizeof(uint32_t)));
   children.Append(absl::string_view(buf, buf_len));
   status->SetPayload(kChildrenPropertyUrl, std::move(children));

--- a/native_src/src/core/lib/security/credentials/external/external_account_credentials.cc
+++ b/native_src/src/core/lib/security/credentials/external/external_account_credentials.cc
@@ -461,7 +461,7 @@ void ExternalAccountCredentials::OnImpersenateServiceAccountInternal(
         "Invalid expire time of service account impersonation response."));
     return;
   }
-  int expire_in = (t - absl::Now()) / absl::Seconds(1);
+  int expire_in = (int)( (t - absl::Now()) / absl::Seconds(1) );
   std::string body = absl::StrFormat(
       "{\"access_token\":\"%s\",\"expires_in\":%d,\"token_type\":\"Bearer\"}",
       access_token, expire_in);

--- a/native_src/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/native_src/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -373,7 +373,7 @@ absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
   if (cert_chain.empty()) {
     return absl::InvalidArgumentError("Certificate string is empty.");
   }
-  BIO* cert_bio = BIO_new_mem_buf(cert_chain.data(), cert_chain.size());
+  BIO* cert_bio = BIO_new_mem_buf(cert_chain.data(), (int)(cert_chain.size()));
   if (cert_bio == nullptr) {
     return absl::InvalidArgumentError(
         "Conversion from certificate string to BIO failed.");
@@ -393,7 +393,7 @@ absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
         "Extraction of public key from x.509 certificate failed.");
   }
   BIO* private_key_bio =
-      BIO_new_mem_buf(private_key.data(), private_key.size());
+      BIO_new_mem_buf(private_key.data(), (int)(private_key.size()));
   if (private_key_bio == nullptr) {
     EVP_PKEY_free(public_evp_pkey);
     return absl::InvalidArgumentError(

--- a/native_src/src/core/lib/security/credentials/tls/tls_utils.cc
+++ b/native_src/src/core/lib/security/credentials/tls/tls_utils.cc
@@ -81,7 +81,7 @@ bool VerifySubjectAlternativeName(absl::string_view subject_alternative_name,
     return false;
   }
   if (!absl::EndsWith(normalized_matcher, suffix)) return false;
-  int suffix_start_index = normalized_matcher.length() - suffix.length();
+  int suffix_start_index = (int)(normalized_matcher.length() - suffix.length());
   // Asterisk matching across domain labels is not permitted.
   return suffix_start_index <= 0 /* should not happen */ ||
          normalized_matcher.find_last_of('.', suffix_start_index - 1) ==

--- a/native_src/src/core/lib/transport/metadata_batch.h
+++ b/native_src/src/core/lib/transport/metadata_batch.h
@@ -559,7 +559,7 @@ class ParseHelper {
     return ParsedMetadata<Container>(
         trait,
         ParseValueToMemento<typename Trait::MementoType, Trait::ParseMemento>(),
-        transport_size_);
+        (uint32_t)transport_size_);
   }
 
   GPR_ATTRIBUTE_NOINLINE ParsedMetadata<Container> NotFound(

--- a/native_src/src/core/lib/transport/parsed_metadata.h
+++ b/native_src/src/core/lib/transport/parsed_metadata.h
@@ -138,7 +138,7 @@ class ParsedMetadata {
   // Construct metadata from a string key, slice value pair.
   ParsedMetadata(Slice key, Slice value)
       : vtable_(ParsedMetadata::KeyValueVTable(key.as_string_view())),
-        transport_size_(key.size() + value.size() + 32) {
+        transport_size_((uint32_t)(key.size() + value.size() + 32)) {
     value_.pointer =
         new std::pair<Slice, Slice>(std::move(key), std::move(value));
   }
@@ -178,7 +178,7 @@ class ParsedMetadata {
     result.vtable_ = vtable_;
     result.value_ = value_;
     result.transport_size_ =
-        TransportSize(vtable_->key(value_).length(), value.length());
+        TransportSize((uint32_t)(vtable_->key(value_).length()), (uint32_t)(value.length()));
     vtable_->with_new_value(&value, on_error, &result);
     return result;
   }

--- a/native_src/third_party/abseil-cpp/absl/random/internal/pcg_engine.h
+++ b/native_src/third_party/abseil-cpp/absl/random/internal/pcg_engine.h
@@ -262,7 +262,7 @@ struct pcg_xsl_rr_128_64 {
     uint64_t rotate = h >> 58u;
     uint64_t s = Uint128Low64(state) ^ h;
 #endif
-    return rotr(s, rotate);
+    return rotr(s, (int)rotate);
   }
 };
 

--- a/native_src/third_party/re2/util/rune.cc
+++ b/native_src/third_party/re2/util/rune.cc
@@ -26,7 +26,7 @@ enum
 	Bit2	= 5,
 	Bit3	= 4,
 	Bit4	= 3,
-	Bit5	= 2, 
+	Bit5	= 2,
 
 	T1	= ((1<<(Bit1+1))-1) ^ 0xFF,	/* 0000 0000 */
 	Tx	= ((1<<(Bitx+1))-1) ^ 0xFF,	/* 1000 0000 */
@@ -76,7 +76,7 @@ chartorune(Rune *rune, const char *str)
 		l = ((c << Bitx) | c1) & Rune2;
 		if(l <= Rune1)
 			goto bad;
-		*rune = l;
+		*rune = (Rune)l;
 		return 2;
 	}
 
@@ -91,7 +91,7 @@ chartorune(Rune *rune, const char *str)
 		l = ((((c << Bitx) | c1) << Bitx) | c2) & Rune3;
 		if(l <= Rune2)
 			goto bad;
-		*rune = l;
+		*rune = (Rune)l;
 		return 3;
 	}
 
@@ -106,7 +106,7 @@ chartorune(Rune *rune, const char *str)
 		l = ((((((c << Bitx) | c1) << Bitx) | c2) << Bitx) | c3) & Rune4;
 		if (l <= Rune3)
 			goto bad;
-		*rune = l;
+		*rune = (Rune)l;
 		return 4;
 	}
 
@@ -220,7 +220,7 @@ utflen(const char *s)
 		c = *(unsigned char*)s;
 		if(c < Runeself) {
 			if(c == 0)
-				return n;
+				return (int)n;
 			s++;
 		} else
 			s += chartorune(&rune, s);

--- a/native_src/third_party/upb/upb/decode_internal.h
+++ b/native_src/third_party/upb/upb/decode_internal.h
@@ -132,7 +132,7 @@ const char *decode_isdonefallback(upb_decstate *d, const char *ptr,
 
 UPB_INLINE
 bool decode_isdone(upb_decstate *d, const char **ptr) {
-  int overrun = *ptr - d->end;
+  int overrun = (int)(*ptr - d->end);
   if (UPB_LIKELY(*ptr < d->limit_ptr)) {
     return false;
   } else if (UPB_LIKELY(overrun == d->limit)) {

--- a/native_src/third_party/upb/upb/def.c
+++ b/native_src/third_party/upb/upb/def.c
@@ -815,7 +815,7 @@ int upb_oneofdef_numfields(const upb_oneofdef *o) {
 }
 
 uint32_t upb_oneofdef_index(const upb_oneofdef *o) {
-  return o - o->parent->oneofs;
+  return (uint32_t)(o - o->parent->oneofs);
 }
 
 bool upb_oneofdef_issynthetic(const upb_oneofdef *o) {
@@ -1884,7 +1884,7 @@ static void create_enumdef(
 
   e->file = ctx->file;
   e->defaultval = 0;
-  e->value_count = n;
+  e->value_count = (int)n;
   e->values = symtab_alloc(ctx, sizeof(*e->values) * n);
 
   if (n == 0) {
@@ -1983,7 +1983,7 @@ static void create_msgdef(symtab_addctx *ctx, const char *prefix,
     create_fielddef(ctx, m->full_name, m, fields[i]);
   }
 
-  m->ext_range_count = n_ext_range;
+  m->ext_range_count = (int)n_ext_range;
   m->ext_ranges = symtab_alloc(ctx, sizeof(*m->ext_ranges) * n_ext_range);
   for (i = 0; i < n_ext_range; i++) {
     const google_protobuf_DescriptorProto_ExtensionRange *r = ext_ranges[i];

--- a/native_src/third_party/upb/upb/msg.c
+++ b/native_src/third_party/upb/upb/msg.c
@@ -56,13 +56,13 @@ static bool realloc_internal(upb_msg *msg, size_t need, upb_arena *arena) {
     size_t size = UPB_MAX(128, _upb_lg2ceilsize((int)(need + overhead)));
     upb_msg_internaldata *internal = upb_arena_malloc(arena, size);
     if (!internal) return false;
-    internal->size = size;
+    internal->size = (uint32_t)size;
     internal->unknown_end = overhead;
-    internal->ext_begin = size;
+    internal->ext_begin = (uint32_t)size;
     in->internal = internal;
   } else if (in->internal->ext_begin - in->internal->unknown_end < need) {
     /* Internal data is too small, reallocate. */
-    size_t new_size = _upb_lg2ceilsize(in->internal->size + need);
+    size_t new_size = _upb_lg2ceilsize((uint32_t)(in->internal->size + need));
     size_t ext_bytes = in->internal->size - in->internal->ext_begin;
     size_t new_ext_begin = new_size - ext_bytes;
     upb_msg_internaldata *internal =
@@ -73,8 +73,8 @@ static bool realloc_internal(upb_msg *msg, size_t need, upb_arena *arena) {
       char *ptr = (char*)internal;
       memmove(ptr + new_ext_begin, ptr + internal->ext_begin, ext_bytes);
     }
-    internal->ext_begin = new_ext_begin;
-    internal->size = new_size;
+    internal->ext_begin = (uint32_t)new_ext_begin;
+    internal->size = (uint32_t)new_size;
     in->internal = internal;
   }
   UPB_ASSERT(in->internal->ext_begin - in->internal->unknown_end >= need);
@@ -249,13 +249,13 @@ static void _upb_mapsorter_getkeys(const void *_a, const void *_b, void *a_key,
 static int _upb_mapsorter_cmpi64(const void *_a, const void *_b) {
   int64_t a, b;
   _upb_mapsorter_getkeys(_a, _b, &a, &b, 8);
-  return a - b;
+  return (int)(a - b);
 }
 
 static int _upb_mapsorter_cmpu64(const void *_a, const void *_b) {
   uint64_t a, b;
   _upb_mapsorter_getkeys(_a, _b, &a, &b, 8);
-  return a - b;
+  return (int)(a - b);
 }
 
 static int _upb_mapsorter_cmpi32(const void *_a, const void *_b) {
@@ -282,12 +282,12 @@ static int _upb_mapsorter_cmpstr(const void *_a, const void *_b) {
   size_t common_size = UPB_MIN(a.size, b.size);
   int cmp = memcmp(a.data, b.data, common_size);
   if (cmp) return cmp;
-  return a.size - b.size;
+  return (int)(a.size - b.size);
 }
 
 bool _upb_mapsorter_pushmap(_upb_mapsorter *s, upb_descriptortype_t key_type,
                             const upb_map *map, _upb_sortedmap *sorted) {
-  int map_size = _upb_map_size(map);
+  int map_size = (int)_upb_map_size(map);
   sorted->start = s->size;
   sorted->pos = sorted->start;
   sorted->end = sorted->start + map_size;

--- a/native_src/third_party/upb/upb/reflection.c
+++ b/native_src/third_party/upb/upb/reflection.c
@@ -243,7 +243,7 @@ bool upb_msg_next(const upb_msg *msg, const upb_msgdef *m,
 
   /* Iterate over normal fields, returning the first one that is set. */
   while (++i < n) {
-    const upb_fielddef *f = upb_msgdef_field(m, i);
+    const upb_fielddef *f = upb_msgdef_field(m, (int)i);
     upb_msgval val = _upb_msg_getraw(msg, f);
 
     /* Skip field if unset or empty. */


### PR DESCRIPTION
This patch fixed 32bit conversion warning (-Wshorten-64-to-32) as seem from default SPM build in gRPC C-Core native source. 
 - Note that these are direct conversion fixes addressing the 32bit build warnings as observed in downstream projects.  Upstream fixes are done via https://github.com/grpc/grpc-ios/issues/83 

### Build Test Verification 

```bash
Run SPM sample app build with -Wshorten-64-to-32 turned on 
./scripts/./build_test_spm_samples.sh 

```

----

cc @HannahShiSFB  @sampajano 