### PR TITLE
Fix pod lint error

### DIFF
--- a/gRPC.podspec
+++ b/gRPC.podspec
@@ -26,33 +26,34 @@ Pod::Spec.new do |s|
     s.homepage = 'https://grpc.io'
     s.license  = 'Apache License, Version 2.0'
     s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
-  
+
     s.source = {
       :git => 'https://github.com/grpc/grpc-ios.git',
     }
-  
-    objc_client_root = "native/src/objective-c/GRPCClient"
+
+    native_root = "native"
+    objc_client_root = "#{native_root}/src/objective-c/GRPCClient"
 
     name = 'GRPCClient'
     s.module_name = name
     s.header_dir = name
-  
+
     s.default_subspec = 'Interface', 'GRPCCore', 'Interface-Legacy'
-  
+
     s.pod_target_xcconfig = {
       # This is needed by all pods that depend on gRPC-RxLibrary:
       'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
       'CLANG_WARN_STRICT_PROTOTYPES' => 'NO',
     }
-  
+
     s.ios.deployment_target = '9.0'
     s.osx.deployment_target = '10.10'
     s.tvos.deployment_target = '10.0'
     s.watchos.deployment_target = '4.0'
-  
+
     s.subspec 'Interface-Legacy' do |ss|
       ss.header_mappings_dir = objc_client_root
-  
+
       ss.public_header_files = "#{objc_client_root}/GRPCCall+ChannelArg.h",
                                "#{objc_client_root}/GRPCCall+ChannelCredentials.h",
                                "#{objc_client_root}/GRPCCall+Cronet.h",
@@ -60,7 +61,7 @@ Pod::Spec.new do |s|
                                "#{objc_client_root}/GRPCCall+Tests.h",
                                "#{objc_client_root}/GRPCCallLegacy.h",
                                "#{objc_client_root}/GRPCTypes.h"
-  
+
       ss.source_files = "#{objc_client_root}/GRPCCall+ChannelArg.h",
                         "#{objc_client_root}/GRPCCall+ChannelCredentials.h",
                         "#{objc_client_root}/GRPCCall+Cronet.h",
@@ -70,16 +71,16 @@ Pod::Spec.new do |s|
                         "#{objc_client_root}/GRPCTypes.h",
                         "#{objc_client_root}/GRPCTypes.m"
       ss.dependency "gRPC-RxLibrary/Interface", version
-  
+
       ss.ios.deployment_target = '9.0'
       ss.osx.deployment_target = '10.10'
       ss.tvos.deployment_target = '10.0'
       ss.watchos.deployment_target = '4.0'
     end
-  
+
     s.subspec 'Interface' do |ss|
       ss.header_mappings_dir = objc_client_root
-  
+
       ss.public_header_files = "#{objc_client_root}/GRPCCall.h",
                                "#{objc_client_root}/GRPCCall+Interceptor.h",
                                "#{objc_client_root}/GRPCCallOptions.h",
@@ -87,7 +88,7 @@ Pod::Spec.new do |s|
                                "#{objc_client_root}/GRPCTransport.h",
                                "#{objc_client_root}/GRPCDispatchable.h",
                                "#{objc_client_root}/version.h"
-  
+
       ss.source_files = "#{objc_client_root}/GRPCCall.h",
                         "#{objc_client_root}/GRPCCall.m",
                         "#{objc_client_root}/GRPCCall+Interceptor.h",
@@ -103,18 +104,18 @@ Pod::Spec.new do |s|
                         "#{objc_client_root}/private/GRPCTransport+Private.h",
                         "#{objc_client_root}/private/GRPCTransport+Private.m",
                         "#{objc_client_root}/version.h"
-  
+
       ss.dependency "#{s.name}/Interface-Legacy", version
-  
+
       ss.ios.deployment_target = '9.0'
       ss.osx.deployment_target = '10.10'
       ss.tvos.deployment_target = '10.0'
       ss.watchos.deployment_target = '4.0'
     end
-  
+
     s.subspec 'GRPCCore' do |ss|
       ss.header_mappings_dir = objc_client_root
-  
+
       ss.public_header_files = "#{objc_client_root}/GRPCCall+ChannelCredentials.h",
                                "#{objc_client_root}/GRPCCall+Cronet.h",
                                "#{objc_client_root}/GRPCCall+OAuth2.h",
@@ -133,50 +134,51 @@ Pod::Spec.new do |s|
                         "#{objc_client_root}/GRPCCall+Tests.h",
                         "#{objc_client_root}/GRPCCall+Tests.m",
                         "#{objc_client_root}/GRPCCallLegacy.m"
-  
+
       # Certificates, to be able to establish TLS connections:
-      ss.resource_bundles = { 'gRPCCertificates' => ['etc/roots.pem'] }
-  
+      ss.resource_bundles = { 'gRPCCertificates' => ["#{native_root}/etc/roots.pem"] }
+
       ss.dependency "#{s.name}/Interface-Legacy", version
       ss.dependency "#{s.name}/Interface", version
       ss.dependency 'gRPC-Core', version
       ss.dependency 'gRPC-RxLibrary', version
-  
+
       ss.ios.deployment_target = '9.0'
       ss.osx.deployment_target = '10.10'
       ss.tvos.deployment_target = '10.0'
       ss.watchos.deployment_target = '4.0'
     end
-  
-    s.subspec 'GRPCCoreCronet' do |ss|
-      ss.header_mappings_dir = objc_client_root
-  
-      ss.source_files = "#{objc_client_root}/GRPCCall+Cronet.h",
-                        "#{objc_client_root}/GRPCCall+Cronet.m",
-                        "#{objc_client_root}/private/GRPCCore/GRPCCoreCronet/*.{h,m}"
-      ss.dependency "#{s.name}/GRPCCore", version
-      ss.dependency 'gRPC-Core/Cronet-Implementation', version
-      ss.dependency 'CronetFramework'
-  
-      ss.ios.deployment_target = '9.0'
-    end
-  
+
+    # TODO(https://github.com/grpc/grpc-ios/issues/119): re-enable after adding device arch support.
+    # s.subspec 'GRPCCoreCronet' do |ss|
+    #   ss.header_mappings_dir = objc_client_root
+
+    #   ss.source_files = "#{objc_client_root}/GRPCCall+Cronet.h",
+    #                     "#{objc_client_root}/GRPCCall+Cronet.m",
+    #                     "#{objc_client_root}/private/GRPCCore/GRPCCoreCronet/*.{h,m}"
+    #   ss.dependency "#{s.name}/GRPCCore", version
+    #   ss.dependency 'gRPC-Core/Cronet-Implementation', version
+    #   ss.dependency 'CronetFramework'
+
+    #   ss.ios.deployment_target = '9.0'
+    # end
+
     # CFStream is now default. Leaving this subspec only for compatibility purpose.
     s.subspec 'CFStream' do |ss|
       ss.dependency "#{s.name}/GRPCCore", version
-  
+
       ss.ios.deployment_target = '9.0'
       ss.osx.deployment_target = '10.10'
       ss.tvos.deployment_target = '10.0'
       ss.watchos.deployment_target = '4.0'
     end
-  
+
     s.subspec 'InternalTesting' do |ss|
       ss.dependency "#{s.name}/GRPCCore", version
       ss.public_header_files = "#{objc_client_root}/internal_testing/*.h"
       ss.source_files = "#{objc_client_root}/internal_testing/*.{h,m}"
       ss.header_mappings_dir = objc_client_root
-  
+
       ss.ios.deployment_target = '9.0'
       ss.osx.deployment_target = '10.10'
       ss.tvos.deployment_target = '10.0'

--- a/scripts/lint_test_cocoapod_spec.sh
+++ b/scripts/lint_test_cocoapod_spec.sh
@@ -3,19 +3,21 @@ set -ex
 
 # Default to build with library with optional build using framework
 BUILD_OPTION="--use-libraries"
-if [[ $1 == "framework" ]]; then 
+if [[ $1 == "framework" ]]; then
     BUILD_OPTION="--use-static-frameworks"
-fi 
+fi
 
 # gRPC ObjC Podspecs
-GRPC_PODSPECS="gRPC-ProtoRPC.podspec gRPC.podspec"
+GRPC_PODSPECS="gRPC.podspec gRPC-ProtoRPC.podspec"
 
 ## Verify via cocoapod lint
+##
 for PODSPEC in $GRPC_PODSPECS; do
     time pod spec lint $PODSPEC $BUILD_OPTION \
     --allow-warnings \
-    --platforms=ios,macos \
     --skip-tests \
+    --fail-fast \
+    --platforms=ios,macos \
     --verbose
 done
 


### PR DESCRIPTION
### Change Summary 

* Disable GRPCCoreCronet until https://github.com/grpc/grpc-ios/issues/119 resolved for Cronet framework pod 
* Resource bundle path fix 
* Enable fail fast on pod lint script 

### Test & Verify 

manual post submit run pass green 

https://github.com/grpc/grpc-ios/actions/runs/3056694595/jobs/4931108361

----
Lint error 

```bash
its entitlements use a placeholder team ID. To resolve this, select a development team in the App editor. (in target 'App' from project 'App')
2022-09-08T01:23:44.5765580Z     - NOTE  | [gRPC/Interface-Legacy, gRPC/Interface, gRPC/GRPCCore, and more...] xcodebuild:  note: Using codesigning identity override: 
2022-09-08T01:23:44.5766180Z     - ERROR | [gRPC/GRPCCore] file patterns: The `resource_bundles` pattern for `gRPCCertificates` did not match any file.
2022-09-08T01:23:44.5766840Z     - ERROR | [OSX] [gRPC/GRPCCoreCronet] unknown: Encountered an unknown error (Platform `macOS` is not supported by specification `gRPC/GRPCCoreCronet (1.44.0)`.
```
