### PR TITLE
Migrate gRPC-RxLibrary pod and enable post-submit lint check

### DIFF
--- a/.github/workflows/post_submit_check.yml
+++ b/.github/workflows/post_submit_check.yml
@@ -1,4 +1,4 @@
-name: Post submit tests and validations on main development branch 
+name: Post submit checks
 on:
   push:
     branches:
@@ -6,11 +6,29 @@ on:
   repository_dispatch:
     types: [post-submit-check]
 jobs:
-  Post-Submit-Check-Main-Branch:
+  post-submit-check-cocoapod-lint-gRPC:
     runs-on: macos-latest
     steps:
-      - name: Repo Checkout 
+      - name: Repo Checkout
         uses: actions/checkout@v2
 
-      - name: gRPC Cocoapod Podspec Validation 
-        run: scripts/lint_test_cocoapod_spec.sh
+      - name: gRPC podspec lint checks
+        run: scripts/lint_test_cocoapod_spec.sh -p gRPC.podspec
+
+  post-submit-check-cocoapod-lint-gRPC-ProtoRPC:
+    runs-on: macos-latest
+    steps:
+      - name: Repo Checkout
+        uses: actions/checkout@v2
+
+      - name: gRPC-ProtoRPC podspec lint checks
+        run: scripts/lint_test_cocoapod_spec.sh -p gRPC-ProtoRPC.podspec
+
+  post-submit-check-cocoapod-lint-gRPC-RxLibrary:
+    runs-on: macos-latest
+    steps:
+      - name: Repo Checkout
+        uses: actions/checkout@v2
+
+      - name: gRPC-RxLibrary podspec lint checks
+        run: scripts/lint_test_cocoapod_spec.sh -p build/cocoapod/gRPC-RxLibrary.podspec

--- a/build/cocoapod/gRPC-RxLibrary.podspec
+++ b/build/cocoapod/gRPC-RxLibrary.podspec
@@ -1,0 +1,70 @@
+# This file has been automatically generated from a template file.
+# Please make modifications to
+# `templates/gRPC-RxLibrary.podspec.template` instead. This file can be
+# regenerated from the template by running
+# `tools/buildgen/generate_projects.sh`.
+
+# Copyright 2022 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+Pod::Spec.new do |s|
+    s.name     = 'gRPC-RxLibrary'
+    version = '1.44.0'
+    s.version  = version
+    s.summary  = 'Reactive Extensions library for iOS/OSX.'
+    s.homepage = 'https://grpc.io'
+    s.license  = 'Apache License, Version 2.0'
+    s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
+
+    s.source = {
+      :git => 'https://github.com/grpc/grpc-ios.git',
+    }
+
+    s.ios.deployment_target = '9.0'
+    s.osx.deployment_target = '10.10'
+    s.tvos.deployment_target = '10.0'
+    s.watchos.deployment_target = '4.0'
+
+    native_root = 'native'
+    src_dir = "#{native_root}/src/objective-c/RxLibrary"
+
+    name = 'RxLibrary'
+    s.module_name = name
+    s.header_dir = name
+
+    s.default_subspec = 'Interface', 'Implementation'
+
+    s.subspec 'Interface' do |ss|
+      ss.header_mappings_dir = "#{src_dir}"
+      ss.source_files = "#{src_dir}/*.h"
+      ss.public_header_files = "#{src_dir}/*.h"
+    end
+
+    s.subspec 'Implementation' do |ss|
+      ss.header_mappings_dir = "#{src_dir}"
+      ss.source_files = "#{src_dir}/*.m", "#{src_dir}/**/*.{h,m}"
+      ss.private_header_files = "#{src_dir}/**/*.h"
+
+      ss.dependency "#{s.name}/Interface"
+    end
+
+    s.source_files = "#{src_dir}/*.{h,m}", "#{src_dir}/**/*.{h,m}"
+    s.private_header_files = "#{src_dir}/private/*.h"
+    s.header_mappings_dir = "#{src_dir}"
+
+    s.pod_target_xcconfig = {
+      'CLANG_WARN_STRICT_PROTOTYPES' => 'NO',
+    }
+  end

--- a/scripts/lint_test_cocoapod_spec.sh
+++ b/scripts/lint_test_cocoapod_spec.sh
@@ -3,15 +3,35 @@ set -ex
 
 # Default to build with library with optional build using framework
 BUILD_OPTION="--use-libraries"
-if [[ $1 == "framework" ]]; then
-    BUILD_OPTION="--use-static-frameworks"
-fi
 
 # gRPC ObjC Podspecs
-GRPC_PODSPECS="gRPC.podspec gRPC-ProtoRPC.podspec"
+GRPC_PODSPECS="
+    gRPC.podspec \
+    gRPC-ProtoRPC.podspec \
+    build/cocoapod/gRPC-RxLibrary.podspec
+"
 
-## Verify via cocoapod lint
-##
+# Parsing arguments
+# -f: use framework build
+# -p: [PODSPEC_NAME] lint test the specified podspec
+while getopts "hfp:" option; do
+   case $option in
+      f)
+         echo "use frameworks"
+         BUILD_OPTION="--use-static-frameworks"
+         ;;
+      p)
+         GRPC_PODSPECS="$OPTARG"
+         ;;
+     \?|h)
+        echo "Usage: -h for help, -f for framework build, -p to specify podspec"
+        exit 1
+   esac
+done
+
+echo "linting podspec '${GRPC_PODSPECS}' "
+
+# Verify via cocoapod lint
 for PODSPEC in $GRPC_PODSPECS; do
     time pod spec lint $PODSPEC $BUILD_OPTION \
     --allow-warnings \


### PR DESCRIPTION
### Change Summary

Migrate [gRPC-RxLibrary](https://github.com/grpc/grpc/blob/master/gRPC-RxLibrary.podspec) to gRPC-iOS. 
- Added podspec for gRPC-RxLibrary under build/cocoapod as this is a internal lib pod dependency 
- Parameterize lint test script to take in individual podspec 
- post submit git action update 

### Test & Verify 

check post-submit pass green on gRPC-RxLibrary