### PR TITLE
[nit] Trigger post submit check after dev release done

### DIFF
--- a/.github/workflows/dev_release_cocoapod.yml
+++ b/.github/workflows/dev_release_cocoapod.yml
@@ -41,7 +41,7 @@ jobs:
           genv --default-signal=PIPE yes | scripts/delete_pod_version.sh gRPC $version
 
       - name: Pod release
-        run: scripts/release_cocoapod.sh build/cocoapod/gRPC.podspec
+        run: scripts/release_cocoapod.sh gRPC.podspec
 
   release-cocoapod-gRPC-ProtoRPC:
     runs-on: macos-latest
@@ -59,4 +59,4 @@ jobs:
           genv --default-signal=PIPE yes | scripts/delete_pod_version.sh gRPC-ProtoRPC $version
 
       - name: Pod release
-        run: scripts/release_cocoapod.sh build/cocoapod/gRPC-ProtoRPC.podspec
+        run: scripts/release_cocoapod.sh gRPC-ProtoRPC.podspec

--- a/.github/workflows/post_submit_check.yml
+++ b/.github/workflows/post_submit_check.yml
@@ -1,8 +1,9 @@
 name: Post submit checks
 on:
-  push:
-    branches:
-      - 'main'
+  workflow_run:
+    workflows: ["Cocoapod dev release"]
+    types: [completed]
+    branches: [main]
   repository_dispatch:
     types: [post-submit-check]
 jobs:
@@ -10,7 +11,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Repo Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: main
 
       - name: gRPC podspec lint checks
         run: scripts/lint_test_cocoapod_spec.sh -p gRPC.podspec
@@ -19,7 +22,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Repo Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: main
 
       - name: gRPC-ProtoRPC podspec lint checks
         run: scripts/lint_test_cocoapod_spec.sh -p gRPC-ProtoRPC.podspec
@@ -28,7 +33,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Repo Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: main
 
       - name: gRPC-RxLibrary podspec lint checks
         run: scripts/lint_test_cocoapod_spec.sh -p build/cocoapod/gRPC-RxLibrary.podspec

--- a/tests/cocoapod/gRPCSample/Podfile
+++ b/tests/cocoapod/gRPCSample/Podfile
@@ -1,3 +1,4 @@
+source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '9.0'
 
 GRPC_PODSPEC_ROOT = '../../..'


### PR DESCRIPTION
* Post submit, wait for updated dev cocoapod version pushed to trunk before running our post submit checks. 
* Minor path fix for gRPC & gRPC-ProtoRPC podspec 