### PR TITLE
[NIT] remove platform override for pod lint

### DIFF
--- a/scripts/lint_test_cocoapod_spec.sh
+++ b/scripts/lint_test_cocoapod_spec.sh
@@ -37,7 +37,6 @@ for PODSPEC in $GRPC_PODSPECS; do
     --allow-warnings \
     --skip-tests \
     --fail-fast \
-    --platforms=ios,macos \
     --verbose
 done
 


### PR DESCRIPTION
remove platform override to let podspec define specific supported platforms to lint against. Fixing post submit lint error 

<https://github.com/grpc/grpc-ios/actions/runs/3102573918/jobs/5025008383#logs> 