### PR TITLE
Adding checker script to wait for a pod release availability

### DIFF
--- a/.github/workflows/dev_release_cocoapod.yml
+++ b/.github/workflows/dev_release_cocoapod.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Pod release
         run: scripts/release_cocoapod.sh build/cocoapod/gRPC-RxLibrary.podspec
 
+      - name: Wait for pod avaialble
+        run: |
+          version=$(cat VERSION)
+          timeout 1h scripts/wait_for_pod_release.sh gRPC-RxLibrary $version
+
   release-cocoapod-gRPC:
     runs-on: macos-latest
     needs: release-cocoapod-gRPC-RxLibrary
@@ -49,6 +54,11 @@ jobs:
       - name: Pod release
         run: scripts/release_cocoapod.sh gRPC.podspec
 
+      - name: Wait for pod avaialble
+        run: |
+          version=$(cat VERSION)
+          timeout 1h scripts/wait_for_pod_release.sh gRPC $version
+
   release-cocoapod-gRPC-ProtoRPC:
     runs-on: macos-latest
     needs: [release-cocoapod-gRPC-RxLibrary, release-cocoapod-gRPC]
@@ -69,3 +79,8 @@ jobs:
 
       - name: Pod release
         run: scripts/release_cocoapod.sh gRPC-ProtoRPC.podspec
+
+      - name: Wait for pod avaialble
+        run: |
+          version=$(cat VERSION)
+          timeout 1h scripts/wait_for_pod_release.sh gRPC-ProtoRPC $version

--- a/scripts/wailt_for_pod_release.sh
+++ b/scripts/wailt_for_pod_release.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+# Utility script to check for a target pod version's availability in pod trunk
+# Script exit without error if found
+# Usage: timeout 60s ./wait_for_pod_release.sh [POD_NAME] [VERSION]
+
+POD_NAME=$1
+POD_VERSION=$2
+
+while true
+do
+   echo "Checking pod availability for ${POD_NAME}, version ${POD_VERSION}"
+   pod repo update --silent
+   results=$(pod trunk info $POD_NAME | grep $POD_VERSION) || true
+   if [[ $results == *"${POD_VERSION}"* ]]; then
+    echo "Version found!"
+    break
+   fi
+done
+
+
+


### PR DESCRIPTION
## Change Summary 

Pod trunk push have delays which usually requires manual wait for the pod to become available for usage. This script automate the process of updating local pod cache and checking for pod availability. 

## Test & Verify 

post submit release job pass green with the new wait script finding the pushed version and exit. 