### PR TITLE
Update concurrency rule for pre submit and post submit

### DIFF
--- a/.github/workflows/dev_release_cocoapod.yml
+++ b/.github/workflows/dev_release_cocoapod.yml
@@ -6,7 +6,7 @@ on:
   repository_dispatch:
     types: [cocoapod-release-dev]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}
   cancel-in-progress: true
 env:
   COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.github/workflows/post_submit_check.yml
+++ b/.github/workflows/post_submit_check.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
   repository_dispatch:
     types: [post-submit-check]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: false
 jobs:
   post-submit-check-cocoapod-lint-gRPC:
     runs-on: macos-latest

--- a/.github/workflows/pre_submit_check.yml
+++ b/.github/workflows/pre_submit_check.yml
@@ -5,6 +5,9 @@ on:
       - 'main'
   repository_dispatch:
     types: [pre-submit-check]
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 jobs:
   pre-submit-spm-build-test:
     runs-on: macos-latest


### PR DESCRIPTION
## Summary 

- Pre-submit check limits to only 1 active run per pull request
   * Previous run will be cancelled if a PR is updated and re-triggered 
- Post-submit check limits to 1 active run, all later runs will wait and pending until earlier runs are finished 
   * This helps us capture regression & breaks on individual merged PR. 