### PR TITLE
[nit] fix minor workflow issue

### DIFF
--- a/.github/workflows/dev_release_cocoapod.yml
+++ b/.github/workflows/dev_release_cocoapod.yml
@@ -11,15 +11,15 @@ concurrency:
 env:
   COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
 jobs:
-  update-dev-release-tag: 
-    runs-on: macos-latest
-    steps:      
+  update-dev-release-tag:
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-      - name: Collect version 
+      - name: Collect version
         run: |
           echo "VERSION=$(cat VERSION)" >> $GITHUB_ENV
-      - name: Update tags 
+      - name: Update tags
         uses: rickstaa/action-create-tag@v1
         with:
           tag: "v@${{ env.VERSION }}"

--- a/.github/workflows/prod_release_cocoapod.yml
+++ b/.github/workflows/prod_release_cocoapod.yml
@@ -1,7 +1,7 @@
 name: Cocoapod prod release
 on:
   release:
-    types: [published]
+    types: [released, published]
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false


### PR DESCRIPTION
## Summary 

- fix prod release trigger signal to properly trigger for released event 
- run action-create-tag from linux node which is not available on macos x 