### PR TITLE
Disable pod lint during trunk push

### DIFF
--- a/scripts/release_cocoapod.sh
+++ b/scripts/release_cocoapod.sh
@@ -11,6 +11,9 @@ if [ -z "$TARGET_PODSPEC" ]; then
     exit 1
 fi
 
+# Skip lint during pod trunk push
+./scripts/skip_pod_push_lint.sh
+
 echo "Publishing podspec $TARGET_PODSPEC"
 
 time pod trunk push $TARGET_PODSPEC \

--- a/scripts/skip_pod_push_lint.sh
+++ b/scripts/skip_pod_push_lint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Script to disable pod lint during trunk push.
+#
+# The script provides an ad-hoc patch to the internal cocoapod push command by removing the
+# validation / lint steps. The script should be relatively stable for runners with a fixed virtual
+# mac os x image, but may require updates to the Gem/Trunk versioning if upgrading to a new runner
+set -ex
+
+# env setup
+GEM_VERSION=2.7.0
+POD_TRUNK_VERSION=1.6.0
+
+# PUSH_FILE_DIR="/Library/Ruby/Gems/2.6.0/gems/cocoapods-trunk-1.6.0/lib/pod/command/trunk"
+PUSH_FILE_DIR="/usr/local/lib/ruby/gems/${GEM_VERSION}/gems/cocoapods-trunk-${POD_TRUNK_VERSION}/lib/pod/command/trunk"
+
+# remove validation steps
+pushd $PUSH_FILE_DIR
+sudo sed -i "" 's/^ *validate_podspec//' push.rb
+popd


### PR DESCRIPTION
### Change Summary 

adding steps to disable pod lint during trunk push which takes significantly long time that execeed github's [6 hour per job limitations ](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits). 
 - we are already running pod lint in a separate [workflow post submit](https://github.com/grpc/grpc-ios/blob/main/.github/workflows/post_submit_check.yml)  

this enables us to complete all pod push for all four platforms (ios,macos, tvos, watchos) within the time limits for release automation 

### Test & Verify 

trigger dev release post submit to verify 
trigger prod release from release branch to verify 