### PR TITLE
Adding c-core release automation workflow

### DIFF
--- a/.github/workflows/prod_release_cocoapod.yml
+++ b/.github/workflows/prod_release_cocoapod.yml
@@ -8,6 +8,43 @@ concurrency:
 env:
   COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
 jobs:
+  release-cocoapod-gRPC-Core:
+    runs-on: macos-latest
+    steps:
+      - name: Repo checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Prepare environment
+        run: scripts/prepare_env.sh
+
+      - name: Pod release
+        run: scripts/release_cocoapod.sh native/gRPC-Core.podspec
+
+      - name: Wait for pod avaialble
+        run: |
+          version=$(cat VERSION)
+          timeout 1h scripts/wait_for_pod_release.sh gRPC-Core $version
+  release-cocoapod-gRPC-Cpp:
+    runs-on: macos-latest
+    needs: [release-cocoapod-gRPC-Core]
+    steps:
+      - name: Repo checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Prepare environment
+        run: scripts/prepare_env.sh
+
+      - name: Pod release
+        run: scripts/release_cocoapod.sh native/gRPC-C++.podspec
+
+      - name: Wait for pod avaialble
+        run: |
+          version=$(cat VERSION)
+          timeout 1h scripts/wait_for_pod_release.sh gRPC-C++ $version
   release-cocoapod-gRPC-RxLibrary:
     runs-on: macos-latest
     steps:
@@ -29,7 +66,7 @@ jobs:
 
   release-cocoapod-gRPC:
     runs-on: macos-latest
-    needs: release-cocoapod-gRPC-RxLibrary
+    needs: [release-cocoapod-gRPC-RxLibrary, release-cocoapod-gRPC-Core]
     steps:
       - name: Repo checkout
         uses: actions/checkout@v3

--- a/scripts/release_cocoapod.sh
+++ b/scripts/release_cocoapod.sh
@@ -5,6 +5,8 @@ set -ex
 # Usage: ./release_cocoapod.sh [PODSPEC_FILE]
 
 TARGET_PODSPEC=$1
+TARGET_DIR=$(dirname $TARGET_PODSPEC)
+TARGET_FILE=$(basename $TARGET_PODSPEC)
 
 if [ -z "$TARGET_PODSPEC" ]; then
     echo "ERROR: please specify podspec"
@@ -16,11 +18,12 @@ fi
 
 echo "Publishing podspec $TARGET_PODSPEC"
 
-time pod trunk push $TARGET_PODSPEC \
+pushd ${TARGET_DIR}
+time pod trunk push $TARGET_FILE \
     --allow-warnings \
     --use-libraries \
     --skip-tests \
     --skip-import-validation \
     --synchronous \
     --verbose
-
+popd


### PR DESCRIPTION
### Summary 

adding release automation for two c-core pods including gRPC-Core and gRPC-C++. These are native pods that need to be released prior to objc pods 

### Test & Verify 

trigger pod release workflow and verify all pods are pushed to trunk w/o issue 

