### PR TITLE
Exclude ios tests from swift package

### DIFF
--- a/.github/workflows/pre_submit_check.yml
+++ b/.github/workflows/pre_submit_check.yml
@@ -2,8 +2,8 @@ name: Pre submit checks
 on:
   pull_request:
     branches:
-      - 'main'
-      - 'grpc_release_**'
+      - "main"
+      - "grpc_release_**"
   repository_dispatch:
     types: [pre-submit-check]
 concurrency:
@@ -12,6 +12,9 @@ concurrency:
 jobs:
   pre-submit-spm-build-package:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        platform: [iOS, macOS, tvOS]
     steps:
       - name: repo checkout
         uses: actions/checkout@v3
@@ -22,7 +25,7 @@ jobs:
         run: scripts/prepare_env.sh
 
       - name: spm package build
-        run: scripts/build_spm_package.sh
+        run: scripts/build_spm_package.sh generic/platform=${{ matrix.platform }}
 
   pre-submit-spm-build-test:
     runs-on: macos-latest

--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,7 @@ let package = Package(
         "src/core/ext/xds/google_mesh_ca_certificate_provider_factory.h",
         "src/core/ext/xds/google_mesh_ca_certificate_provider_factory.cc",
         "src/objective-c/examples/",
+        "src/objective-c/manual_tests/",
         "src/objective-c/tests/",
         "third_party/re2/re2/testing/",
         "third_party/re2/re2/fuzzing/",
@@ -113,6 +114,7 @@ let package = Package(
         "src/cpp/util/core_stats.h",
         "src/cpp/util/error_details.cc",
         "src/objective-c/examples/",
+        "src/objective-c/manual_tests/",
         "src/objective-c/tests/",
       ],
       sources: [

--- a/Package.swift
+++ b/Package.swift
@@ -61,6 +61,7 @@ let package = Package(
       ],
       sources: [
         "src/core/ext/filters/",
+        "src/core/ext/gcp/",
         "src/core/ext/transport/",
         "src/core/ext/upb-generated/",
         "src/core/ext/upbdefs-generated/",

--- a/scripts/build_spm_package.sh
+++ b/scripts/build_spm_package.sh
@@ -8,10 +8,12 @@ source ./scripts/build_commons.sh
 # build configuration and paths
 SCHEME=gRPC-Package
 
+DESTINATION="${1:-$GRPC_IOS_DESTINATION}"
+
 # build via xcodebuild command line
 time xcodebuild \
 -scheme $SCHEME \
 -verbose \
--destination "${GRPC_IOS_DESTINATION}" \
+-destination "${DESTINATION}" \
 build \
 $GRPC_IOS_BUILD_FLAGS

--- a/tests/cocoapod/gRPCSample/Podfile
+++ b/tests/cocoapod/gRPCSample/Podfile
@@ -6,7 +6,6 @@ install! 'cocoapods', :deterministic_uuids => false
 GRPC_PODSPEC_ROOT = '../../../native'
 
 target 'gRPCSample' do
-  use_frameworks!
   pod 'gRPC-ProtoRPC',  :path => GRPC_PODSPEC_ROOT
   pod 'gRPC', :path => GRPC_PODSPEC_ROOT
   pod 'gRPC-RxLibrary', :path => GRPC_PODSPEC_ROOT


### PR DESCRIPTION
This excludes `src/objective-c/manual_tests/` from swift package build, fixes https://github.com/firebase/firebase-ios-sdk/pull/10650 building for macos and tvos. Also added them to CI.


@sampajano 