### PR TITLE
fix header_mappings_dir () is not a directory error

### DIFF
--- a/gRPC-C++.podspec
+++ b/gRPC-C++.podspec
@@ -2798,7 +2798,8 @@ Pod::Spec.new do |s|
 
     ss.dependency 'gRPC-Core/Cronet-Implementation', version
 
-    ss.source_files = "src/cpp/client/cronet_credentials.cc"
+    ss.source_files = "include/grpcpp/security/cronet_credentials.h",
+                      "src/cpp/client/cronet_credentials.cc"
   end
 
   # patch include of openssl to openssl_grpc


### PR DESCRIPTION
Validation error when pushing gRPC-C++ podspec:
```
2024-04-22T05:05:34.3096470Z     - ERROR | [gRPC-C++/Privacy] header_mappings_dir: The header_mappings_dir (`include/grpcpp`) is not a directory.
2024-04-22T05:05:34.3097950Z [!] The spec did not pass validation, due to 1 error.
```
This ensures Cronet-Implementation subspec has a file in "include/grpcpp" directory.
