### PR TITLE
use pip to install pyyaml

### DIFF
--- a/scripts/prepare_env.sh
+++ b/scripts/prepare_env.sh
@@ -9,4 +9,6 @@ set -ex
 # GNU command line tools
 brew install coreutils
 
-brew install pyyaml
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install pyyaml


### PR DESCRIPTION
pyyaml deprecated from homebrew
https://github.com/Homebrew/homebrew-core/pull/176591