### PR TITLE
use venv when syncing grpc sources

### DIFF
--- a/.github/workflows/grpc_source_sync.yml
+++ b/.github/workflows/grpc_source_sync.yml
@@ -15,7 +15,9 @@ jobs:
         run: scripts/prepare_env.sh
 
       - name: Shallow source source
-        run: scripts/sync_grpc_src_shallow.sh
+        run: |
+          source .venv/bin/activate
+          scripts/sync_grpc_src_shallow.sh
 
       - name: Collect revision hash
         run: |


### PR DESCRIPTION
Fix the [gRPC Source Sync](https://github.com/grpc/grpc-ios/actions/runs/12150330292) work flow