### PR TITLE
dont skip pod push lint

### DIFF
--- a/scripts/release_cocoapod.sh
+++ b/scripts/release_cocoapod.sh
@@ -13,9 +13,6 @@ if [ -z "$TARGET_PODSPEC" ]; then
     exit 1
 fi
 
-# Skip lint during pod trunk push
-./scripts/skip_pod_push_lint.sh
-
 echo "Publishing podspec $TARGET_PODSPEC"
 
 pushd ${TARGET_DIR}


### PR DESCRIPTION
skip_pod_push_lint.sh does not work with new macos versions.
while lint is being fixed, skip the patch so we can see what other lint failures are there