### PR TITLE
updated the script for pod push

### DIFF
--- a/scripts/release_cocoapod.sh
+++ b/scripts/release_cocoapod.sh
@@ -13,17 +13,64 @@ if [ -z "$TARGET_PODSPEC" ]; then
     exit 1
 fi
 
+pushd ${TARGET_DIR}
+
+POD_NAME="${TARGET_FILE%.podspec}"
+POD_VERSION=$(grep -E "^\s*(s\.)?version\s*=" "$TARGET_FILE" | head -n 1 | awk -F"['\"]" '{print $2}')
+
+echo "Checking if $POD_NAME ($POD_VERSION) is already published on CocoaPods Trunk..."
+if pod trunk info "$POD_NAME" | grep -q -- "- ${POD_VERSION} ("; then
+    echo "SKIP: $POD_NAME ($POD_VERSION) is already published on CocoaPods Trunk. Skipping push!"
+    popd
+    exit 0
+fi
+
+popd
+
 # Configure pod trunk push lint to validate on iOS only (--no-subspecs --fail-fast)
 "$(dirname "$0")/skip_pod_push_lint.sh"
 
 echo "Publishing podspec $TARGET_PODSPEC"
 
 pushd ${TARGET_DIR}
+
+LOG_FILE=$(mktemp)
+set +e
 time pod trunk push $TARGET_FILE \
     --allow-warnings \
     --use-libraries \
     --skip-tests \
     --skip-import-validation \
     --synchronous \
-    --verbose
+    --verbose 2>&1 | tee "$LOG_FILE"
+PUSH_EXIT_CODE=${PIPESTATUS[0]}
+set -e
+
+if [ $PUSH_EXIT_CODE -ne 0 ]; then
+    if grep -q "The spec did not pass validation" "$LOG_FILE"; then
+        echo "ERROR: Podspec validation failed for $TARGET_FILE"
+        rm -f "$LOG_FILE"
+        exit 1
+    fi
+
+    echo "WARNING: pod trunk push exited with code $PUSH_EXIT_CODE. Checking if $POD_NAME ($POD_VERSION) was published to Trunk..."
+    sleep 15
+    if pod trunk info "$POD_NAME" | grep -q -- "- ${POD_VERSION} ("; then
+        echo "SUCCESS: $POD_NAME ($POD_VERSION) is published on CocoaPods Trunk despite 500 response!"
+        rm -f "$LOG_FILE"
+        popd
+        exit 0
+    fi
+
+    echo "Retrying pod trunk push for $TARGET_FILE..."
+    time pod trunk push $TARGET_FILE \
+        --allow-warnings \
+        --use-libraries \
+        --skip-tests \
+        --skip-import-validation \
+        --synchronous \
+        --verbose
+fi
+rm -f "$LOG_FILE"
+
 popd


### PR DESCRIPTION
Update release script: Add validation checks and retry logic for CocoaPods

This pull request updates the `release_cocoapod.sh` script to improve the robustness of the release workflow:

1. Skip Push if Already Published: Added a check to verify if the pod version already exists on CocoaPods Trunk before attempting a push.
2. Improved Validation: The script now strictly ensures that pod validation passes before proceeding with the push.
3. Resilience Against Network Errors: If `pod trunk push` fails due to a server error (e.g., HTTP 500) but the pod was actually published, the script waits 15 seconds to verify the status via `pod trunk info`. If the push truly failed, it now performs a single retry.
